### PR TITLE
PlayerSelectionコンポーネントの作成

### DIFF
--- a/frontend/components/molecules/PlayerListItem.tsx
+++ b/frontend/components/molecules/PlayerListItem.tsx
@@ -5,7 +5,7 @@ import {
   Select,
 } from "@chakra-ui/react";
 import {Player, RankMMR} from "@/types/game";
-import {generateInitialMMRs} from "@/lib/Mmr";
+import {getAllRankMMRList} from "@/lib/Mmr";
 import {useMemo} from "react";
 import {ValueChangeDetails} from "@zag-js/select";
 
@@ -26,7 +26,7 @@ export function PlayerListItem({
                                }: PlayerListItemProps) {
   const ranks = useMemo(
     () => createListCollection({
-      items: generateInitialMMRs(),
+      items: getAllRankMMRList(),
     }),
     []
   )

--- a/frontend/components/organisms/PlayerSelection.tsx
+++ b/frontend/components/organisms/PlayerSelection.tsx
@@ -1,0 +1,53 @@
+import { Card } from '@chakra-ui/react';
+import { PlayerListHeader } from '../molecules/PlayerListHeader';
+import { PlayerListItem } from '../molecules/PlayerListItem';
+import { PlayerListFooter } from '../molecules/PlayerListFooter';
+import type { Player, RankMMR } from '@/types/game';
+import { ValueChangeDetails } from "@zag-js/select";
+
+interface PlayerSelectionProps {
+  allPlayers: Player[];
+  selectedPlayerIds: Set<string>;
+  onTogglePlayer: (playerId: string) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onUpdateRank: (playerId: string, rank: ValueChangeDetails<RankMMR>) => void;
+}
+
+export function PlayerSelection({
+  allPlayers,
+  selectedPlayerIds,
+  onTogglePlayer,
+  onSelectAll,
+  onDeselectAll,
+  onUpdateRank,
+}: PlayerSelectionProps) {
+  return (
+    <Card.Root className="p-4 bg-slate-800/50 border-slate-700">
+      <Card.Header>
+        <PlayerListHeader onSelectAll={onSelectAll} onDeselectAll={onDeselectAll} />
+      </Card.Header>
+
+      <Card.Body>
+        <div className="space-y-2">
+          {allPlayers.map((player) => (
+            <PlayerListItem
+              key={player.id}
+              player={player}
+              isSelected={selectedPlayerIds.has(player.id)}
+              onToggle={() => onTogglePlayer(player.id)}
+              onUpdateRank={(rank) => onUpdateRank(player.id, rank)}
+            />
+          ))}
+        </div>
+      </Card.Body>
+
+      <Card.Footer>
+        <PlayerListFooter
+          totalPlayers={allPlayers.length}
+          selectedCount={selectedPlayerIds.size}
+        />
+      </Card.Footer>
+    </Card.Root>
+  );
+}

--- a/frontend/lib/MMR.ts
+++ b/frontend/lib/MMR.ts
@@ -1,0 +1,129 @@
+import { Rank, Division, RankMMR } from '@/types/game';
+
+/**
+ * ランクごとのベースMMR値
+ * LOLのランクシステムに基づいたMMR値を定義
+ */
+const RANK_BASE_MMR: Record<Rank, number> = {
+  Iron: 0,
+  Bronze: 400,
+  Silver: 800,
+  Gold: 1200,
+  Platinum: 1600,
+  Diamond: 2000,
+  Master: 2400,
+  Grandmaster: 2700,
+  Challenger: 3000,
+};
+
+/**
+ * ディビジョンごとのMMRオフセット値
+ * IV → III → II → I の順にMMRが上昇
+ * ランク間400差を4等分（100ずつ）
+ */
+const DIVISION_OFFSET: Record<Division, number> = {
+  IV: 0,
+  III: 100,
+  II: 200,
+  I: 300,
+};
+
+/**
+ * ランクとディビジョンからMMRを計算
+ * @param rank プレイヤーのランク
+ * @param division プレイヤーのディビジョン（Master以上は不要）
+ * @returns 計算されたMMR値
+ */
+export function calculateMMR(rank: Rank, division?: Division): number {
+  const baseMmr = RANK_BASE_MMR[rank];
+  
+  // Master以上はディビジョンなし
+  if (rank === 'Master' || rank === 'Grandmaster' || rank === 'Challenger') {
+    return baseMmr;
+  }
+  
+  // ディビジョンが指定されていない場合はベースMMRを返す
+  if (!division) {
+    return baseMmr;
+  }
+  
+  return baseMmr + DIVISION_OFFSET[division];
+}
+
+/**
+ * すべてのランクとディビジョンの組み合わせのMMRリストを取得
+ * @returns RankMMRの配列（MMRが低い順）
+ */
+export function getAllRankMMRList(): RankMMR[] {
+  const rankList: RankMMR[] = [];
+  
+  // ディビジョンがあるランク
+  const ranksWithDivision: Rank[] = ['Iron', 'Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond'];
+  const divisions: Division[] = ['IV', 'III', 'II', 'I'];
+  
+  // ディビジョン付きランクを追加
+  ranksWithDivision.forEach(rank => {
+    divisions.forEach(division => {
+      rankList.push({
+        rank,
+        division,
+        baseMmr: calculateMMR(rank, division),
+      });
+    });
+  });
+  
+  // Master以上を追加
+  const masterTiers: Rank[] = ['Master', 'Grandmaster', 'Challenger'];
+  masterTiers.forEach(rank => {
+    rankList.push({
+      rank,
+      baseMmr: calculateMMR(rank),
+    });
+  });
+  
+  return rankList;
+}
+
+/**
+ * 特定のランクのMMR範囲を取得
+ * @param rank ランク
+ * @returns { min: 最小MMR, max: 最大MMR }
+ */
+export function getRankMMRRange(rank: Rank): { min: number; max: number } {
+  const allRanks: Rank[] = [
+    'Iron', 'Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond',
+    'Master', 'Grandmaster', 'Challenger'
+  ];
+  
+  const currentIndex = allRanks.indexOf(rank);
+  const min = RANK_BASE_MMR[rank];
+  
+  // 最上位ランク以外は次のランクのベースMMRが最大値
+  if (currentIndex < allRanks.length - 1) {
+    const max = RANK_BASE_MMR[allRanks[currentIndex + 1]];
+    return { min, max };
+  }
+  
+  // Challengerの場合は上限なし
+  return { min, max: Infinity };
+}
+
+/**
+ * MMR値からランクとディビジョンを推定
+ * @param mmr MMR値
+ * @returns RankMMR
+ */
+export function getRankFromMMR(mmr: number): RankMMR {
+  const allRanks = getAllRankMMRList();
+  
+  // MMR値に最も近いランクを見つける（降順で探索）
+  for (let i = allRanks.length - 1; i >= 0; i--) {
+    if (mmr >= allRanks[i].baseMmr) {
+      return allRanks[i];
+    }
+  }
+  
+  // 最低ランクを返す
+  return allRanks[0];
+}
+


### PR DESCRIPTION
## 変更内容

プレイヤー選択機能の基盤となるMMR計算ライブラリとPlayerSelectionコンポーネントを実装

## 変更の種類

- [x] feat✨: 新しい機能や改善を追加
- [x] refactor♻️: パフォーマンス改善やリファクタリング

## 変更範囲

- [x] ui: ユーザーインターフェースの変更

## 変更の詳細

### 変更した理由

プレイヤー選択画面でランクとディビジョンに基づいた公平なチーム分けを行うため、MMR計算とプレイヤー選択UIが必要だった

### 変更した内容

#### ✨ MMR計算ライブラリの追加（`frontend/lib/MMR.ts`）

League of Legendsのランクシステムに基づいたMMR計算機能を実装
- `calculateMMR()`: ランクとディビジョンからMMR値を計算
- `getAllRankMMRList()`: すべてのランク・ディビジョンの組み合わせリストを取得
- `getRankMMRRange()`: 特定ランクのMMR範囲を取得
- `getRankFromMMR()`: MMR値からランクを逆算

**MMR定義：**
- Iron: 0, Bronze: 400, Silver: 800, Gold: 1200, Platinum: 1600, Diamond: 2000
- Master: 2400, Grandmaster: 2700, Challenger: 3000
- ディビジョンごとに100ずつオフセット（IV→III→II→I）

#### 🎨 PlayerSelectionコンポーネントの追加（`frontend/components/organisms/PlayerSelection.tsx`）

プレイヤー選択機能を統合したorganismsレイヤーのコンポーネント
- Header: 全選択・解除ボタン（PlayerListHeader）
- Body: プレイヤーリスト表示・選択・ランク変更（PlayerListItem）
- Footer: 合計人数・選択数表示（PlayerListFooter）

#### ♻️ PlayerListItemのリファクタリング

`generateInitialMMRs()` → `getAllRankMMRList()` に変更し、新しく追加したMMRライブラリを活用

## テスト

- [x] ローカルで動作確認済み
- [ ] 既存機能への影響を確認済み
- [ ] エラーが発生しないことを確認済み

### テスト内容

- MMR計算ロジックの動作確認
- PlayerSelectionコンポーネントの表示確認
- プレイヤー選択・ランク変更機能の動作確認

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 不要なコメントやデバッグコードを削除した
- [x] コミットメッセージが適切である
- [ ] 関連するドキュメントを更新した（必要な場合）

## 補足

このPRはプレイヤー選択機能の基盤実装です。MMR計算ロジックとプレイヤー選択UIを追加し、今後のチーム分けアルゴリズム実装への準備を整えました。