### PR TITLE
#13 チーム表示コンポーネントを追加

### DIFF
--- a/frontend/components/organisms/TeamDisplay.tsx
+++ b/frontend/components/organisms/TeamDisplay.tsx
@@ -1,0 +1,33 @@
+import { TeamCard } from '../molecules/TeamCard';
+import type { Teams } from '@/types/game';
+
+const TEAM_COLORS = {
+    BLUE: 'blue',
+    RED: 'red',
+} as const;
+
+type TeamColor = (typeof TEAM_COLORS)[keyof typeof TEAM_COLORS];
+
+interface TeamDisplayProps {
+    teams: Teams;
+    onRecordResult: (winner: TeamColor) => void;
+}
+
+export function TeamDisplay({ teams, onRecordResult }: TeamDisplayProps) {
+    return (
+        <div className="space-y-4">
+            <TeamCard
+                teamName="ブルーチーム"
+                players={teams.blue}
+                teamColor={TEAM_COLORS.BLUE}
+                onWin={() => onRecordResult(TEAM_COLORS.BLUE)}
+            />
+            <TeamCard
+                teamName="レッドチーム"
+                players={teams.red}
+                teamColor={TEAM_COLORS.RED}
+                onWin={() => onRecordResult(TEAM_COLORS.RED)}
+            />
+        </div>
+    );
+}

--- a/frontend/components/organisms/TeamDisplay.tsx
+++ b/frontend/components/organisms/TeamDisplay.tsx
@@ -1,10 +1,6 @@
 import { TeamCard } from '../molecules/TeamCard';
 import type { Teams, TeamColor } from '@/types/game';
-
-const TEAM_COLORS = {
-    BLUE: 'blue',
-    RED: 'red',
-} as const;
+import { TEAM_COLORS } from '@/lib/const';
 
 interface TeamDisplayProps {
     teams: Teams;

--- a/frontend/components/organisms/TeamDisplay.tsx
+++ b/frontend/components/organisms/TeamDisplay.tsx
@@ -1,12 +1,10 @@
 import { TeamCard } from '../molecules/TeamCard';
-import type { Teams } from '@/types/game';
+import type { Teams, TeamColor } from '@/types/game';
 
 const TEAM_COLORS = {
     BLUE: 'blue',
     RED: 'red',
 } as const;
-
-type TeamColor = (typeof TEAM_COLORS)[keyof typeof TEAM_COLORS];
 
 interface TeamDisplayProps {
     teams: Teams;

--- a/frontend/lib/const.ts
+++ b/frontend/lib/const.ts
@@ -1,0 +1,4 @@
+export const TEAM_COLORS = {
+    BLUE: 'blue',
+    RED: 'red',
+} as const;

--- a/frontend/types/game.ts
+++ b/frontend/types/game.ts
@@ -1,3 +1,5 @@
+import { TEAM_COLORS } from "@/lib/const";
+
 export interface Player {
   id: string;
   name: string;
@@ -10,13 +12,15 @@ export interface GameRecord {
   date: Date;
   blueTeam: Player[];
   redTeam: Player[];
-  winner: 'blue' | 'red';
+  winner: TeamColor;
 }
 
 export interface Teams {
   blue: Player[];
   red: Player[];
 }
+
+export type TeamColor = (typeof TEAM_COLORS)[keyof typeof TEAM_COLORS];
 
 export type Rank =
     | 'Iron' | 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond'

--- a/frontend/types/game.ts
+++ b/frontend/types/game.ts
@@ -13,6 +13,11 @@ export interface GameRecord {
   winner: 'blue' | 'red';
 }
 
+export interface Teams {
+  blue: Player[];
+  red: Player[];
+}
+
 export type Rank =
     | 'Iron' | 'Bronze' | 'Silver' | 'Gold' | 'Platinum' | 'Diamond'
     | 'Master' | 'Grandmaster' | 'Challenger'


### PR DESCRIPTION
## 変更内容

チーム分け結果を表示するTeamDisplayコンポーネントを実装

## 変更の種類

- [x] feat✨: 新しい機能や改善を追加

## 変更範囲

- [x] ui: ユーザーインターフェースの変更

## 変更の詳細

### 変更した理由

カスタムゲームのチーム分け結果を表示し、勝利チームを記録するためのUIコンポーネントが必要だった

### 変更した内容

#### 🎨 TeamDisplayコンポーネントの追加（`frontend/components/organisms/TeamDisplay.tsx`）

チーム分け結果を表示するorganismsレイヤーのコンポーネント
- ブルーチームとレッドチームを並べて表示
- 各チームに勝利ボタンを配置し、勝利結果を記録可能
- チームカラーの型安全な管理（TEAM_COLORS定数を使用）

**主な機能：**
- 既存の`TeamCard`コンポーネントを活用してチーム情報を表示
- `onRecordResult`コールバックで勝利チームを親コンポーネントに通知
- TypeScriptの型安全性を確保（TeamColor型の定義）

#### 📝 Teams型の追加（`frontend/types/game.ts`）

チームデータの型定義を追加
```typescript
export interface Teams {
  blue: Player[];
  red: Player[];
}
```

## テスト

- [x] ローカルで動作確認済み
- [ ] 既存機能への影響を確認済み
- [ ] エラーが発生しないことを確認済み

### テスト内容

- TeamDisplayコンポーネントの表示確認
- 勝利ボタンのクリック動作確認
- 型定義の適用確認

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 不要なコメントやデバッグコードを削除した
- [x] コミットメッセージが適切である
- [ ] 関連するドキュメントを更新した（必要な場合）

## 補足

このPRは#15（PlayerSelection機能）に続く実装です。プレイヤー選択後のチーム分け結果表示に必要なUIコンポーネントを追加し、ゲーム結果記録機能への準備を整えました。