### PR TITLE
feat✨(ui): 試合履歴表示コンポーネントを追加

### DIFF
--- a/frontend/components/organisms/GameHistory.tsx
+++ b/frontend/components/organisms/GameHistory.tsx
@@ -1,0 +1,55 @@
+import { memo } from 'react';
+import { Badge } from '@chakra-ui/react'; 
+import { Trophy } from 'lucide-react';
+import GameHistoryItem from '@/components/molecules/GameHistoryItem';
+import type { GameRecord } from '@/types/game';
+
+interface GameHistoryProps {
+  gameHistory: GameRecord[];
+}
+
+export const GameHistory = memo(({ gameHistory }: GameHistoryProps) => {
+  if (gameHistory.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <Trophy 
+          className="size-16 text-slate-600 mx-auto mb-4 opacity-30" 
+          aria-hidden="true"
+        />
+        <h3 className="text-slate-400 mb-2">まだ試合履歴がありません</h3>
+        <p className="text-slate-500 text-sm">
+          チームを作成して勝敗を記録すると、ここに表示されます
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-slate-200 flex items-center gap-2">
+          <Trophy 
+            className="size-5 text-yellow-500" 
+            aria-hidden="true"
+          />
+          試合履歴
+        </h2>
+        <Badge colorScheme="gray" variant="subtle">
+          {gameHistory.length}試合
+        </Badge>
+      </div>
+
+      <div className="space-y-4">
+        {gameHistory.map((game, index) => (
+          <GameHistoryItem
+            key={game.id}
+            game={game}
+            gameNumber={gameHistory.length - index}
+          />
+        ))}
+      </div>
+    </div>
+  );
+});
+
+GameHistory.displayName = 'GameHistory';

--- a/frontend/components/organisms/PlayerSelection.tsx
+++ b/frontend/components/organisms/PlayerSelection.tsx
@@ -30,7 +30,7 @@ export function PlayerSelection({
 
       <Card.Body>
         <div className="space-y-2">
-          {allPlayers.map((player: Player) => (
+          {allPlayers.map((player) => (
             <PlayerListItem
               key={player.id}
               player={player}

--- a/frontend/components/organisms/PlayerSelection.tsx
+++ b/frontend/components/organisms/PlayerSelection.tsx
@@ -30,7 +30,7 @@ export function PlayerSelection({
 
       <Card.Body>
         <div className="space-y-2">
-          {allPlayers.map((player) => (
+          {allPlayers.map((player: Player) => (
             <PlayerListItem
               key={player.id}
               player={player}


### PR DESCRIPTION
## 変更内容
- GameHistoryコンポーネントを新規追加
- 試合履歴の一覧表示機能を実装
- エンプティステート（履歴がない場合）の実装

## 実装詳細
- `GameHistoryItem` を使用した試合履歴の表示
- 試合数のバッジ表示
- lucide-reactのTrophyアイコンを使用したUI

## 主な機能
✨ 試合履歴がない場合の親切なエンプティステート
✨ 試合数のカウント表示
✨ 試合番号の降順表示（最新が上）

## チェックリスト
- [x] コンポーネントの実装
- [x] 型定義の追加
- [x] エンプティステートの実装